### PR TITLE
Fix retain on readerView causing leak

### DIFF
--- a/iphone/ZBarReaderViewController.m
+++ b/iphone/ZBarReaderViewController.m
@@ -218,6 +218,7 @@ AVSessionPresetForUIVideoQuality (UIImagePickerControllerQualityType quality)
     [cameraSim release];
     cameraSim = nil;
     readerView.readerDelegate = nil;
+    [readerView removeFromSuperview];
     [readerView release];
     readerView = nil;
     [controls release];


### PR DESCRIPTION
Fixes a leak on iOS 7 where ZBarReaderViewController causes a leak in the readerView and eventually crashes when opened multiple times.
