### PR TITLE
Fix memory leak of view.

### DIFF
--- a/iphone/ZBarReaderViewController.m
+++ b/iphone/ZBarReaderViewController.m
@@ -320,8 +320,9 @@ AVSessionPresetForUIVideoQuality (UIImagePickerControllerQualityType quality)
 
 - (void) loadView
 {
-    self.view = [[UIView alloc]
-                    initWithFrame: CGRectMake(0, 0, 320, 480)];
+    self.view = [[[UIView alloc]
+                  initWithFrame: CGRectMake(0, 0, 320, 480)]
+                 autorelease];
 }
 
 - (void) viewDidLoad


### PR DESCRIPTION
This memory leak caused the AV capture system to create potentially hundreds of megabytes of notification objects after only a handful of scans. Easy fix.
