### PR TITLE
Use libv4l to avoid having to use LD_PRELOAD.

### DIFF
--- a/zbar/Makefile.am.inc
+++ b/zbar/Makefile.am.inc
@@ -64,12 +64,14 @@ endif
 
 if HAVE_V4L2
 zbar_libzbar_la_SOURCES += zbar/video/v4l.c zbar/video/v4l2.c
+zbar_libzbar_la_LIBADD += -lv4l2
 endif
 if HAVE_V4L1
 if !HAVE_V4L2
 zbar_libzbar_la_SOURCES += zbar/video/v4l.c
 endif
 zbar_libzbar_la_SOURCES += zbar/video/v4l1.c
+zbar_libzbar_la_LIBADD += -lv4l1
 endif
 if WIN32
 if HAVE_VIDEO

--- a/zbar/video/v4l.c
+++ b/zbar/video/v4l.c
@@ -34,6 +34,11 @@
 #ifdef HAVE_UNISTD_H
 # include <unistd.h>
 #endif
+#ifdef HAVE_LINUX_VIDEODEV2_H
+# include <libv4l2.h>
+#else
+# include <libv4l1.h>
+#endif
 
 #include "video.h"
 
@@ -43,7 +48,11 @@ extern int _zbar_v4l2_probe(zbar_video_t*);
 int _zbar_video_open (zbar_video_t *vdo,
                       const char *dev)
 {
-    vdo->fd = open(dev, O_RDWR);
+#ifdef HAVE_LINUX_VIDEODEV2_H
+    vdo->fd = v4l2_open(dev, O_RDWR);
+#else
+    vdo->fd = v4l1_open(dev, O_RDWR);
+#endif
     if(vdo->fd < 0)
         return(err_capture_str(vdo, SEV_ERROR, ZBAR_ERR_SYSTEM, __func__,
                                "opening video device '%s'", dev));
@@ -60,7 +69,11 @@ int _zbar_video_open (zbar_video_t *vdo,
 #endif
 
     if(rc && vdo->fd >= 0) {
-        close(vdo->fd);
+#ifdef HAVE_LINUX_VIDEODEV2_H
+        v4l2_close(vdo->fd);
+#else
+        v4l1_close(vdo->fd);
+#endif
         vdo->fd = -1;
     }
     return(rc);


### PR DESCRIPTION
This is recommanded by V4L.
