### PR TITLE
Support BIG-5 QRCode

### DIFF
--- a/README
+++ b/README
@@ -1,3 +1,13 @@
+ZBAR WITH BIG-5 ENCODING QRCODE
+====================
+
+This forked project fixes the issues that caused ZBar using wrong encoding for BIG-5 encoded text in QRCode. I only change qrdectxt.c file to add BIG-5 support and you should find no problem using the original encoding for QRCode such as ISO8859-1, SJIS, UTF-8.
+
+Since Taiwan E-Invoice allows both BIG-5 and UTF-8 encoding as QRCode. I modify the original project to support BIG-5 which may be helpful for some developers in Taiwan.
+More information about Taiwan E-Invoice: https://www.einvoice.nat.gov.tw/
+
+
+
 ZBAR BAR CODE READER
 ====================
 

--- a/ZBarSDK.podspec
+++ b/ZBarSDK.podspec
@@ -7,6 +7,8 @@ Pod::Spec.new do |s|
   s.homepage = 'http://zbar.sourceforge.net/'
   s.author   = { 'Jeff Brown' => 'spadix@users.sourceforge.net' }
   s.source   = { :git => 'https://github.com/ZBar/ZBar.git', :tag => 'iPhoneSDK-1.3.1' }
+  s.requires_arc = false
+
 
   s.description  = 'ZBar is an open source software suite for reading bar codes from various sources, such as video streams, ' \
                    'image files and raw intensity sensors. It supports many popular symbologies (types of bar codes) including ' \

--- a/ZBarSDK.podspec
+++ b/ZBarSDK.podspec
@@ -1,0 +1,36 @@
+Pod::Spec.new do |s|
+  s.name     = 'ZBarSDK'
+  s.version  = '1.3.1'
+  s.platform = :ios
+  s.license  = 'GNU LGPL 2.1'
+  s.summary  = 'QR and barcode scan library.'
+  s.homepage = 'http://zbar.sourceforge.net/'
+  s.author   = { 'Jeff Brown' => 'spadix@users.sourceforge.net' }
+  s.source   = { :git => 'https://github.com/ZBar/ZBar.git', :tag => 'iPhoneSDK-1.3.1' }
+
+  s.description  = 'ZBar is an open source software suite for reading bar codes from various sources, such as video streams, ' \
+                   'image files and raw intensity sensors. It supports many popular symbologies (types of bar codes) including ' \
+                   'EAN-13/UPC-A, UPC-E, EAN-8, Code 128, Code 39, Interleaved 2 of 5 and QR Code.'
+
+  s.public_header_files = 'iphone/**/**/*.h', 'include/*.h'
+
+  s.source_files = 'include/zbar.h', 'zbar/**/*.h', 'iphone/*.h', 'iphone/include/**/*.h',
+                   'zbar/{config,decoder,error,image,img_scanner,refcnt,scanner,symbol}.c',
+                   'zbar/decoder/{codabar,code39,code93,code128,databar,ean,i25,qr_finder}.c',
+                   'zbar/qrcode/*.c',
+                   'iphone/*.m'
+
+  s.resources    = 'iphone/res/{zbar-*.png,zbar-help.html}'
+
+  s.frameworks   = 'AVFoundation', 'CoreGraphics', 'CoreMedia', 'CoreVideo', 'QuartzCore'
+
+  s.library      = 'iconv'
+
+  s.xcconfig = { "EXCLUDED_SOURCE_FILE_NAMES[sdk=iphoneos*][arch=*]"        => 'ZBarReaderViewImpl_Simulator.m',
+                 "EXCLUDED_SOURCE_FILE_NAMES[sdk=iphonesimulator*][arch=*]" => 'ZBarReaderViewImpl_Capture.m ZBarCaptureReader.m',
+                 "GCC_PREPROCESSOR_DEFINITIONS"                             => 'NDEBUG=1' }
+
+  s.prefix_header_file = 'iphone/include/prefix.pch'
+
+  s.compiler_flags = '-w'
+end

--- a/zbar/qrcode/qrdectxt.c
+++ b/zbar/qrcode/qrdectxt.c
@@ -187,6 +187,11 @@ int qr_code_data_list_extract_text(const qr_code_data_list *_qrlist,
     enc_list[3]=utf8_cd;
     eci_cd=(iconv_t)-1;
     err=0;
+
+
+    char *bytebuf_text = (char *)malloc((sa_ctext+1)*sizeof(*sa_text));
+    size_t bytebuf_ntext = 0;
+
     for(j = 0; j < sa_size && !err; j++, sym = &(*sym)->next) {
       *sym = _zbar_image_scanner_alloc_sym(iscn, ZBAR_QRCODE, 0);
       (*sym)->datalen = sa_ntext;
@@ -223,11 +228,104 @@ int qr_code_data_list_extract_text(const qr_code_data_list *_qrlist,
       horiz = abs(dir[0]) > abs(dir[1]);
       (*sym)->orient = horiz + 2 * (dir[1 - horiz] < 0);
 
-      for(k=0;k<qrdataj->nentries&&!err;k++){
+      for(k=0;k<=qrdataj->nentries&&!err;k++){
         size_t              inleft;
         size_t              outleft;
         char               *in;
         char               *out;
+
+        // Check if bytebuf_text is empty INSIDE for loop.
+        if(bytebuf_ntext > 0){
+          entry = (k == qrdataj->nentries)? NULL : qrdataj->entries+k;
+          // next entry is not byte mode, convert bytes to text.
+          if(entry == NULL || (entry->mode != QR_MODE_BYTE && entry->mode != QR_MODE_KANJI)){
+            in=bytebuf_text;
+            inleft=bytebuf_ntext;
+            out=sa_text+sa_ntext;
+            outleft=sa_ctext-sa_ntext;
+            /*If we have no specified encoding, attempt to auto-detect it.*/
+            if(eci<0){
+              int ei;
+              /*If there was data encoded in kanji mode, assume it's SJIS.*/
+              if(has_kanji)enc_list_mtf(enc_list,sjis_cd);
+              /*Otherwise check for the UTF-8 BOM.
+                UTF-8 is rarely specified with ECI, and few decoders
+                 currently support doing so, so this is the best way for
+                 encoders to reliably indicate it.*/
+              else if(inleft>=3&&
+               in[0]==(char)0xEF&&in[1]==(char)0xBB&&in[2]==(char)0xBF){
+                in+=3;
+                inleft-=3;
+                /*Actually try converting (to check validity).*/
+                err=utf8_cd==(iconv_t)-1||
+                 iconv(utf8_cd,&in,&inleft,&out,&outleft)==(size_t)-1;
+                if(!err){
+                  sa_ntext=out-sa_text;
+                  enc_list_mtf(enc_list,utf8_cd);
+                  continue;
+                }
+                in=bytebuf_text;
+                inleft=bytebuf_ntext;
+                out=sa_text+sa_ntext;
+                outleft=sa_ctext-sa_ntext;
+              }
+              /*If the text is 8-bit clean, prefer UTF-8 over SJIS, since
+                 SJIS will corrupt the backslashes used for DoCoMo formats.*/
+              else if(text_is_ascii((unsigned char *)in,inleft)){
+                enc_list_mtf(enc_list,utf8_cd);
+              }
+              /* Check if it's big5 encoding. */
+              else if(text_is_big5((unsigned char *)in,inleft)){
+                enc_list_mtf(enc_list,big5_cd);
+              }
+
+              /*Try our list of encodings.*/
+              for(ei=0;ei<4;ei++)if(enc_list[ei]!=(iconv_t)-1){
+                /*According to the 2005 version of the standard,
+                   ISO/IEC 8859-1 (one hyphen) is supposed to be used, but
+                   reality is not always so (and in the 2000 version of the
+                   standard, it was JIS8/SJIS that was the default).
+                  It's got an invalid range that is used often with SJIS
+                   and UTF-8, though, which makes detection easier.
+                  However, iconv() does not properly reject characters in
+                   those ranges, since ISO-8859-1 (two hyphens) defines a
+                   number of seldom-used control code characters there.
+                  So if we see any of those characters, move this
+                   conversion to the end of the list.*/
+                if(ei<3&&enc_list[ei]==latin1_cd&&
+                 !text_is_latin1((unsigned char *)in,inleft)){
+                  int ej;
+                  for(ej=ei+1;ej<4;ej++)enc_list[ej-1]=enc_list[ej];
+                  enc_list[3]=latin1_cd;
+                }
+                err=iconv(enc_list[ei],&in,&inleft,&out,&outleft)==(size_t)-1;
+                if(!err){
+                  sa_ntext=out-sa_text;
+                  enc_list_mtf(enc_list,enc_list[ei]);
+                  break;
+                }
+                in=bytebuf_text;
+                inleft=bytebuf_ntext;
+                out=sa_text+sa_ntext;
+                outleft=sa_ctext-sa_ntext;
+              }
+            }
+            /*We were actually given a character set; use it.
+              The spec says that in this case, data should be treated as if it
+               came from the given character set even when encoded in kanji
+               mode.*/
+            else{
+              err=eci_cd==(iconv_t)-1||
+               iconv(eci_cd,&in,&inleft,&out,&outleft)==(size_t)-1;
+              if(!err)sa_ntext=out-sa_text;
+            }
+            bytebuf_ntext = 0;
+          }
+
+        }
+        if(k == qrdataj->nentries)
+          break;
+
         entry=qrdataj->entries+k;
         switch(entry->mode){
           case QR_MODE_NUM:{
@@ -278,86 +376,11 @@ int qr_code_data_list_extract_text(const qr_code_data_list *_qrlist,
             It requires copying buffers around to handle correctly.*/
           case QR_MODE_BYTE:
           case QR_MODE_KANJI:{
+            // copy byte to bytebuf
             in=(char *)entry->payload.data.buf;
             inleft=entry->payload.data.len;
-            out=sa_text+sa_ntext;
-            outleft=sa_ctext-sa_ntext;
-            /*If we have no specified encoding, attempt to auto-detect it.*/
-            if(eci<0){
-              int ei;
-              /*If there was data encoded in kanji mode, assume it's SJIS.*/
-              if(has_kanji)enc_list_mtf(enc_list,sjis_cd);
-              /*Otherwise check for the UTF-8 BOM.
-                UTF-8 is rarely specified with ECI, and few decoders
-                 currently support doing so, so this is the best way for
-                 encoders to reliably indicate it.*/
-              else if(inleft>=3&&
-               in[0]==(char)0xEF&&in[1]==(char)0xBB&&in[2]==(char)0xBF){
-                in+=3;
-                inleft-=3;
-                /*Actually try converting (to check validity).*/
-                err=utf8_cd==(iconv_t)-1||
-                 iconv(utf8_cd,&in,&inleft,&out,&outleft)==(size_t)-1;
-                if(!err){
-                  sa_ntext=out-sa_text;
-                  enc_list_mtf(enc_list,utf8_cd);
-                  continue;
-                }
-                in=(char *)entry->payload.data.buf;
-                inleft=entry->payload.data.len;
-                out=sa_text+sa_ntext;
-                outleft=sa_ctext-sa_ntext;
-              }
-              /*If the text is 8-bit clean, prefer UTF-8 over SJIS, since
-                 SJIS will corrupt the backslashes used for DoCoMo formats.*/
-              else if(text_is_ascii((unsigned char *)in,inleft)){
-                enc_list_mtf(enc_list,utf8_cd);
-              }
-              /* Check if it's big5 encoding. */
-              else if(text_is_big5((unsigned char *)in,inleft)){
-                enc_list_mtf(enc_list,big5_cd);
-              }
-
-              /*Try our list of encodings.*/
-              for(ei=0;ei<4;ei++)if(enc_list[ei]!=(iconv_t)-1){
-                /*According to the 2005 version of the standard,
-                   ISO/IEC 8859-1 (one hyphen) is supposed to be used, but
-                   reality is not always so (and in the 2000 version of the
-                   standard, it was JIS8/SJIS that was the default).
-                  It's got an invalid range that is used often with SJIS
-                   and UTF-8, though, which makes detection easier.
-                  However, iconv() does not properly reject characters in
-                   those ranges, since ISO-8859-1 (two hyphens) defines a
-                   number of seldom-used control code characters there.
-                  So if we see any of those characters, move this
-                   conversion to the end of the list.*/
-                if(ei<3&&enc_list[ei]==latin1_cd&&
-                 !text_is_latin1((unsigned char *)in,inleft)){
-                  int ej;
-                  for(ej=ei+1;ej<4;ej++)enc_list[ej-1]=enc_list[ej];
-                  enc_list[3]=latin1_cd;
-                }
-                err=iconv(enc_list[ei],&in,&inleft,&out,&outleft)==(size_t)-1;
-                if(!err){
-                  sa_ntext=out-sa_text;
-                  enc_list_mtf(enc_list,enc_list[ei]);
-                  break;
-                }
-                in=(char *)entry->payload.data.buf;
-                inleft=entry->payload.data.len;
-                out=sa_text+sa_ntext;
-                outleft=sa_ctext-sa_ntext;
-              }
-            }
-            /*We were actually given a character set; use it.
-              The spec says that in this case, data should be treated as if it
-               came from the given character set even when encoded in kanji
-               mode.*/
-            else{
-              err=eci_cd==(iconv_t)-1||
-               iconv(eci_cd,&in,&inleft,&out,&outleft)==(size_t)-1;
-              if(!err)sa_ntext=out-sa_text;
-            }
+            memcpy(bytebuf_text+bytebuf_ntext,in,inleft*sizeof(*bytebuf_text));
+            bytebuf_ntext += inleft;
           }break;
           /*Check to see if a character set was specified.*/
           case QR_MODE_ECI:{
@@ -391,7 +414,12 @@ int qr_code_data_list_extract_text(const qr_code_data_list *_qrlist,
         eci=-1;
         if(eci_cd!=(iconv_t)-1)iconv_close(eci_cd);
       }
+
     }
+
+    free(bytebuf_text);
+
+
     if(eci_cd!=(iconv_t)-1)iconv_close(eci_cd);
     if(!err){
       zbar_symbol_t *sa_sym;

--- a/zbar/qrcode/qrdectxt.c
+++ b/zbar/qrcode/qrdectxt.c
@@ -369,11 +369,8 @@ int qr_code_data_list_extract_text(const qr_code_data_list *_qrlist,
               sa_ntext+=inleft;
             }
           }break;
-          /*TODO: This will not handle a multi-byte sequence split between
-             multiple data blocks.
-            Does such a thing occur?
-            Is it allowed?
-            It requires copying buffers around to handle correctly.*/
+          /* DONE: This handles a multi-byte sequence split between
+             multiple data blocks. */
           case QR_MODE_BYTE:
           case QR_MODE_KANJI:{
             // copy byte to bytebuf


### PR DESCRIPTION
Since Taiwan E-Invoice allows both BIG-5 and UTF-8 encoding as QRCode. I modify the original project to support BIG-5 which may be helpful for some developers in Taiwan.

More information about Taiwan E-Invoice: https://www.einvoice.nat.gov.tw/
