### PR TITLE
segfault at zbar_image_convert  if cross compile without libjpeg

### DIFF
--- a/zbar/convert.c
+++ b/zbar/convert.c
@@ -1030,6 +1030,9 @@ zbar_image_t *zbar_image_convert_resize (const zbar_image_t *src,
     func = conversions[srcfmt->group][dstfmt->group].func;
 
     dst->cleanup = zbar_image_free_data;
+    if (NULL == func){
+        return NULL; //fail if cross compile without libjpeg, so return NULL
+    }
     func(dst, dstfmt, src, srcfmt);
     if(!dst->data) {
         /* conversion failed */


### PR DESCRIPTION
I cross compile libzbar, include `config.h`.

`SIGSEGV` caught, and It took some time to figure it out.

However it's not always easy to figure it out in some embedded system, toolchain included gdb in embedded system sometimes not works well as Linux/Unix/Darwin. For example,  I can't list source of current file or function in my arm-linux device, even `make` with the option `-g -O0 -rdynamic`, and sometimes `addr2line` works not as well. And no `execinfo.h`, I can't backtrace with uclibc, I caught `SIGSEGV` but didn't know segment fault at where, which function, which line.

Another significant influence is that program will abort if  segment fault occur. It sounds unreasonable in multithread environment.

I finally found sefault at  `zbar_image_convert_resize` .

I  cross compile without libjpeg, no `-ljpeg`.

I scan jpeg image,  `conversions[ZBAR_FMT_JPEG][ZBAR_FMT_GRAY].func` will be `NULL`, not `_zbar_convert_jpeg_to_y` callback.

I print the value with gdb
```shell
(gdb) p conversions
$33 = {{{cost = 0, func = 0xb6cf3384 <convert_copy>}, {cost = 8, func = 0xb6cf3500 <convert_uvp_append>}, {cost = 24, func = 0xb6cf2114 <convert_yuv_pack>}, {cost = 32, 
      func = 0xb6cf2418 <convert_yuvp_to_rgb>}, {cost = 8, func = 0xb6cf3500 <convert_uvp_append>}, {cost = -1, func = 0x0}}, {{cost = 1, func = 0xb6cf3384 <convert_copy>}, {cost = 48, 
      func = 0xb6cf28e4 <convert_uvp_resample>}, {cost = 64, func = 0xb6cf2114 <convert_yuv_pack>}, {cost = 128, func = 0xb6cf2418 <convert_yuvp_to_rgb>}, {cost = 40, 
      func = 0xb6cf3500 <convert_uvp_append>}, {cost = -1, func = 0x0}}, {{cost = 24, func = 0xb6cf2ae0 <convert_yuv_unpack>}, {cost = 52, func = 0xb6cf2ae0 <convert_yuv_unpack>}, {cost = 20, 
      func = 0xb6cf2c70 <convert_uv_resample>}, {cost = 144, func = 0xb6cf2630 <convert_yuv_to_rgb>}, {cost = 18, func = 0xb6cf2ae0 <convert_yuv_unpack>}, {cost = -1, func = 0x0}}, {{cost = 112, 
      func = 0xb6cf2e3c <convert_rgb_to_yuvp>}, {cost = 160, func = 0xb6cf2e3c <convert_rgb_to_yuvp>}, {cost = 144, func = 0xb6cf30dc <convert_rgb_to_yuv>}, {cost = 120, 
      func = 0xb6cf1e70 <convert_rgb_resample>}, {cost = 152, func = 0xb6cf2e3c <convert_rgb_to_yuvp>}, {cost = -1, func = 0x0}}, {{cost = 1, func = 0xb6cf3384 <convert_copy>}, {cost = 8, 
      func = 0xb6cf3500 <convert_uvp_append>}, {cost = 24, func = 0xb6cf2114 <convert_yuv_pack>}, {cost = 32, func = 0xb6cf2418 <convert_yuvp_to_rgb>}, {cost = 8, 
      func = 0xb6cf3500 <convert_uvp_append>}, {cost = -1, func = 0x0}}, {{cost = -1, func = 0x0}, {cost = -1, func = 0x0}, {cost = -1, func = 0x0}, {cost = -1, func = 0x0}, {cost = -1, func = 0x0}, {
      cost = -1, func = 0x0}}}
(gdb) p conversions[5][0]
$32 = {cost = -1, func = 0x0}
```

suggest 
```cpp
if (NULL == func){
        return (NULL);
}
else{
       func(dst, dstfmt, src, srcfmt);
}
```

so  people will handle the error if  `zbar_image_convert` failed, without bothering another thread. `NULL` returned  if `NULL == func`, we can quickly know the problem and do the error handle.

And I will add `#define HAVE_LIBJPEG 1`,  `#define HAVE_JPEGLIB_H 1`, and `-ljpeg` latter.