### PR TITLE
Add notice to README that new upstream is https://github.com/mchehab/zbar

### DIFF
--- a/README
+++ b/README
@@ -1,3 +1,10 @@
+NEW UPSTREAM REPO
+=================
+
+This repository is no longer maintained you can find the new
+upstream here
+    https://git.linuxtv.org/zbar.git/about/
+
 ZBAR BAR CODE READER
 ====================
 


### PR DESCRIPTION
This repository seems to be abandoned, you should submit patches to [linuxtv](https://github.com/mchehab/zbar) instead.