### PR TITLE
Update to the camera scan

### DIFF
--- a/zbarcam/zbarcam.c
+++ b/zbarcam/zbarcam.c
@@ -113,6 +113,7 @@ static void data_handler (zbar_image_t *img, const void *userdata)
                 continue;
         }
         else if(format == RAW) {
+            _setmode(_fileno(stdout), _O_BINARY);
             if(fwrite(zbar_symbol_get_data(sym),
                       zbar_symbol_get_data_length(sym),
                       1, stdout) != 1)


### PR DESCRIPTION
Just use binary mode when reading raw data.

Line 260 with the XML uses the same assignment...